### PR TITLE
Fix dashboard copy and add auth redirect test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+test-dist/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+The root route immediately redirects based on your session state—authenticated users land on the dashboard while guests are sent to the login screen. To experiment with the UI, edit a page that actually renders content such as `src/app/(protected)/dashboard/page.tsx` or `src/app/auth/login/page.tsx`. The app auto-updates as you edit those files.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const eslintConfig = [
       ".next/**",
       "out/**",
       "build/**",
+      "test-dist/**",
       "next-env.d.ts",
     ],
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "build:test": "tsc -p tsconfig.test.json",
+    "test": "npm run build:test && node --test test-dist/tests/auth-redirect.test.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -762,7 +762,7 @@ function TableCellViewer({ item }: { item: z.infer<typeof schema> }) {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="Done">Done</SelectItem>
-                    <SelectItem value="In Progress">In Progress</SelectItem>
+                    <SelectItem value="In Process">In Process</SelectItem>
                     <SelectItem value="Not Started">Not Started</SelectItem>
                   </SelectContent>
                 </Select>

--- a/src/components/section-cards.tsx
+++ b/src/components/section-cards.tsx
@@ -74,7 +74,7 @@ export function SectionCards() {
           <div className="line-clamp-1 flex gap-2 font-medium">
             Strong user retention <IconTrendingUp className="size-4" />
           </div>
-          <div className="text-muted-foreground">Engagement exceed targets</div>
+          <div className="text-muted-foreground">Engagement exceeds targets</div>
         </CardFooter>
       </Card>
       <Card className="@container/card">

--- a/tests/auth-redirect.test.ts
+++ b/tests/auth-redirect.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { authOptions } from "../src/lib/auth"
+
+function getRedirectCallback() {
+  const redirect = authOptions.callbacks?.redirect
+
+  if (!redirect) {
+    throw new Error("authOptions.callbacks.redirect is not defined")
+  }
+
+  return redirect
+}
+
+test("redirect callback returns auth routes unchanged", async () => {
+  const redirect = getRedirectCallback()
+
+  const result = await redirect({
+    url: "/auth/reset",
+    baseUrl: "http://localhost:3000",
+  })
+
+  assert.equal(result, "/auth/reset")
+})
+
+test("redirect callback sends non-auth routes to the dashboard", async () => {
+  const redirect = getRedirectCallback()
+
+  const result = await redirect({
+    url: "/reports",
+    baseUrl: "http://localhost:3000",
+  })
+
+  assert.equal(result, "http://localhost:3000/dashboard")
+})

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "test-dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": ["tests/**/*.ts", "src/lib/auth.ts"]
+}


### PR DESCRIPTION
## Summary
- correct the Active Accounts card copy and align the status dropdown with the dataset values
- update the README to explain the home route redirect and point to editable pages
- add a Node-based test setup and a redirect callback unit test to prevent regressions

## Testing
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95726634c832681e827c1bd56d58e